### PR TITLE
Make dependencies peerDependencies to avoid duplicate instances

### DIFF
--- a/dist/handlebars-i18n.js
+++ b/dist/handlebars-i18n.js
@@ -31,7 +31,6 @@
  * THE SOFTWARE.
  *
  *********************************************************************/
-console.log('hm');
 
 (function (root, factory) {
 
@@ -157,8 +156,6 @@ console.log('hm');
      * @returns {*}
      */
     init : function() {
-      console.log('init');
-
       handlebars.registerHelper('__',
         /**
          * retrieves the translation phrase from a key given as string
@@ -170,9 +167,6 @@ console.log('hm');
          * @returns {*}
          */
         function (str, attributes) {
-          console.log('translate :)');
-          console.log(i18next.t('testi'));
-
           return new handlebars.SafeString((typeof(i18next) !== 'undefined' ? i18next.t(str, attributes.hash) : str));
         }
       );

--- a/dist/handlebars-i18n.js
+++ b/dist/handlebars-i18n.js
@@ -31,6 +31,7 @@
  * THE SOFTWARE.
  *
  *********************************************************************/
+console.log('hm');
 
 (function (root, factory) {
 
@@ -156,6 +157,8 @@
      * @returns {*}
      */
     init : function() {
+      console.log('init');
+
       handlebars.registerHelper('__',
         /**
          * retrieves the translation phrase from a key given as string
@@ -167,6 +170,9 @@
          * @returns {*}
          */
         function (str, attributes) {
+          console.log('translate :)');
+          console.log(i18next.t('testi'));
+
           return new handlebars.SafeString((typeof(i18next) !== 'undefined' ? i18next.t(str, attributes.hash) : str));
         }
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,14 +221,6 @@
       "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
       "dev": true
     },
-    "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
@@ -1062,7 +1054,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -2957,8 +2950,9 @@
     },
     "handlebars": {
       "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "resolved": "https://tooling.leogistics.cloud:4873/handlebars/-/handlebars-4.7.6.tgz",
       "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -3110,14 +3104,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "i18next": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.8.4.tgz",
-      "integrity": "sha512-FfVPNWv+felJObeZ6DSXZkj9QM1Ivvh7NcFCgA8XPtJWHz0iXVa9BUy+QY8EPrCLE+vWgDfV/sc96BgXVo6HAA==",
-      "requires": {
-        "@babel/runtime": "^7.12.0"
-      }
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3157,11 +3143,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
-    },
-    "intl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
-      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -4033,7 +4014,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -4199,9 +4181,10 @@
       }
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "version": "2.6.2",
+      "resolved": "https://tooling.leogistics.cloud:4873/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "next-tick": {
       "version": "1.0.0",
@@ -5029,11 +5012,6 @@
         "resolve": "^1.1.6"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5444,7 +5422,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -5886,6 +5865,7 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
       "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
+      "dev": true,
       "requires": {
         "commander": "~2.20.3"
       }
@@ -6171,7 +6151,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "workerpool": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-i18n",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "handlebars-i18n adds internationlization to handlebars.js using i18next and Intl",
   "main": "dist/handlebars-i18n.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Florian Walzel",
   "license": "MIT",
   "homepage": "https://github.com/fwalzel/handlebars-i18n.git#readme",
-  "dependencies": {
+  "peerDependencies": {
     "handlebars": "^4.7.6",
     "i18next": "^19.8.4",
     "intl": "^1.2.5"

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,8 @@ Usage in web browser:
 Initialize i18next with your language strings and default settings:
 
 ```
+const i18next = require('i18next');
+
 i18next.init({
 	resources : {
         "en" : {

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ MIT License
 ## Install
 
 ```
-$ npm install handlebars-i18n
+$ npm install handlebars-i18n handlebars i18next intl
 ```
 
 


### PR DESCRIPTION
`handlebars-i18n` does install its own version of handlebars, i18next and intl. When having `handlebars` in a project and using `handlebars-i18n` there are two versions of handlebars. The helpers that `handlebars-i18n` registers go into the instance that `handlebars-i18n` installed and the one actually used in the project does not have the helper.

Example:

```
import * as handlebars from 'handlebars';
import i18next from 'i18next';
import * as HandlebarsI18n from 'handlebars-i18n';

HandlebarsI18n.init(); // -> Registers helpers in its own instance of handlebars

i18next.init({
	resources : {
        "en" : {
            translation : {
                "phrase1": "What is good?",
            }
        },
    },
    lng : "en"
}); 
//  -> This is a different instance of i18next than the one used in handlebars-i18n
```

To fix that I made the dependencies a peerDependency. This also fixes the issue that `handlebars-i18n` may have outdated versions in its package.json which otherwise needs to be updated constantly.

I also updated the readme accordingly.