### PR TITLE
chore(renovate): customize configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
+  "automerge": true,
+  "automergeType": "branch",
   "extends": [
-    "config:base"
-  ]
+    "config:base",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "lockFileMaintenance": { "enabled": true },
+  "major": {
+    "automerge": false
+  }
 }


### PR DESCRIPTION
This is the renovate configuration I use for all my projects, stripped down for this project ([full version](https://github.com/dargmuesli/renovate-config)).

- If there is an update, renovate will create a branch (so that tests can run) and automatically merge the branch, except the version change is on the major level.
- Also renovate will use commit messages that are compatible with semantic releases (in case you decide to implement those for you project too)
- renovate will update the lockfile once a week, so there is less of a change for receiving security vulnerability notices for transitive dependencies